### PR TITLE
Remove reference to the GA4GH API version in the About dialog.

### DIFF
--- a/main.html
+++ b/main.html
@@ -53,7 +53,7 @@ limitations under the License.
       </div>
       <div class="modal-body">
         <p class="lead">GABrowse is a sample application designed to demonstrate the capabilities of the
-        <a href="http://ga4gh.org/#/api">GA4GH API v0.5.1</a>.</p>
+        <a href="http://ga4gh.org/#/api">GA4GH API</a>.</p>
 
         <p>Currently, you can view data from Google and Ensembl.</p>
 


### PR DESCRIPTION
Now supports both 0.5.1 and 0.6.0. I don't think that is critical include in the About dialog.